### PR TITLE
v1.2.3

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 public static class Application
 {
     public const string                botRepoURL      = "https://github.com/egebilecen/PZServerDiscordBot";
-    public const string                botVersion      = "v1.2.2";
+    public const string                botVersion      = "v1.2.3";
     public const float                 botVersionMajor = 1.2f;
 
     public static Settings.BotSettings botSettings;

--- a/src/Scheduler.cs
+++ b/src/Scheduler.cs
@@ -68,7 +68,9 @@ public static class Scheduler
                 if(item.IntervalMS != 0
                 && now >= item.NextExecuteTime)
                 {
-                    item.Function(item.Args);
+                    try { item.Function(item.Args); }
+                    catch(Exception ex) { Logger.LogException(ex, "Exception occured in ScheduleItem callback function. ScheduleItem: "+item.Name); }
+                    
                     item.UpdateInterval();
                 }
             }

--- a/src/Schedules/ServerRestart.cs
+++ b/src/Schedules/ServerRestart.cs
@@ -32,11 +32,9 @@ public static partial class Schedules
         {
             if(isServerRunning)
                 publicChannel.SendMessageAsync("**[Server Restart Schedule]** Restarting server.");
-            else
-                publicChannel.SendMessageAsync("**[Server Restart Schedule]** Server is not running. Skipping...");
         }
         
-        Logger.WriteLog(string.Format("[{0}][Server Restart Schedule] Restarting server. (Is server running: {1})", Logger.GetLoggingDate(), isServerRunning.ToString()));
+        Logger.WriteLog(string.Format("[{0}][Server Restart Schedule] Restarting server if it is running. (Is server running: {1})", Logger.GetLoggingDate(), isServerRunning.ToString()));
         
         Scheduler.GetItem("ServerRestart").UpdateInterval(Application.botSettings.ServerScheduleSettings.ServerRestartSchedule);
 

--- a/src/Schedules/ServerRestartAnnouncer.cs
+++ b/src/Schedules/ServerRestartAnnouncer.cs
@@ -8,6 +8,8 @@ public static partial class Schedules
 {
     public static void ServerRestartAnnouncer(List<object> args)
     {
+        if(!ServerUtility.IsServerRunning()) return;
+
         int[] minuteList = {
             60,
             30,

--- a/src/ServerUtility.cs
+++ b/src/ServerUtility.cs
@@ -51,6 +51,15 @@ public static class ServerUtility
                 serverProcess = new Process();
                 serverProcess.StartInfo = startInfo;
                 serverProcess.Start();
+
+                ScheduleItem serverRestartSchedule  = Scheduler.GetItem("ServerRestart");
+                ScheduleItem serverRestartAnnouncer = Scheduler.GetItem("ServerRestartAnnouncer");
+
+                if(serverRestartSchedule != null)
+                    serverRestartSchedule.UpdateInterval();
+
+                if(serverRestartAnnouncer != null)
+                    serverRestartAnnouncer.UpdateInterval();
             }
 
             return serverProcess;


### PR DESCRIPTION
- workshop mod update checker now will print out mods that is unlisted or private in log channel thus can't fetch it's details
- using `!start_server` or `!restart_server` resets the schedule timer for server restart
- if server is not running, `"server will be restarted in X minutes"` messages won't sent to bot public channel